### PR TITLE
Make subscribe widget show tag feed on tag pages

### DIFF
--- a/plugins/widgets/src/Widgets.php
+++ b/plugins/widgets/src/Widgets.php
@@ -95,6 +95,7 @@ class Widgets
             ->create('subscribe', __('Subscribe links'), [Widgets::class, 'subscribe'], null, 'Feed subscription links (RSS or Atom)')
             ->addTitle(__('Subscribe'))
             ->setting('type', __('Feeds type:'), 'atom', 'combo', ['Atom' => 'atom', 'RSS' => 'rss2'])
+            ->setting('tags', __('Feed for tags'), true, 'check')
             ->addHomeOnly()
             ->addContentOnly()
             ->addClass()
@@ -423,6 +424,7 @@ class Widgets
 
         $p_title = __('This blog\'s entries %s feed');
         $c_title = __('This blog\'s comments %s feed');
+        $t_title = __('This tag\'s entries %s feed');
 
         $res = ($widget->title ? $widget->renderTitle(Html::escapeHTML($widget->title)) : '') .
             '<ul>';
@@ -437,6 +439,15 @@ class Widgets
             'href="' . dcCore::app()->blog->url . dcCore::app()->url->getURLFor('feed', $type . '/comments') . '" ' .
             'title="' . sprintf($c_title, ($type == 'atom' ? 'Atom' : 'RSS')) . '" class="feed">' .
             __('Comments feed') . '</a></li>';
+        }
+
+        if ($widget->tags) {
+            if (dcCore::app()->url->type == 'tag') {
+                $res .= '<li><a type="' . $mime . '" ' .
+                'href="' . dcCore::app()->blog->url . dcCore::app()->url->getURLFor('feed', 'tag/' . dcCore::app()->url->args . '/' . $type) . '" ' .
+                'title="' . sprintf($t_title, ($type == 'atom' ? 'Atom' : 'RSS')) . '" class="feed">' .
+                __('This tag\'s entries feed') . '</a></li>';
+            }
         }
 
         $res .= '</ul>';


### PR DESCRIPTION
Hello!

This may be more of a suggestion than an actual pull request.

It would be cool if the subscribe widget could display links for tags feed (and maybe for categories too for blogs that use them).

This simple proposal would only show the tag feed link on specific tag pages, but it would be even better if the feeds for all the tags of a given post were shown when the widget is present on post pages.

For example, on the home or archive pages, the widget would display:

> * Entries feed

but on `/tag/foo` the widget would display:

> * Entries feed
> * This tag\'s entries feed

and on `/post/yyyy/mm/a-given-post`, a post tagged with both `foo` and `bar` tags, the widget would display:

> * Entries feed
> * Comments feed _[if comments are enabled for this post]_
> * Entries tagged 'foo' feed
> * Entries tagged 'bar' feed

Cheers and thanks for Dotclear :).